### PR TITLE
Add SREC checksum validator

### DIFF
--- a/hexfix/__init__.py
+++ b/hexfix/__init__.py
@@ -1,6 +1,6 @@
 """Convenience imports for hexfix package."""
 
-from .checksum import crc32_for_address_range
+from .checksum import crc32_for_address_range, validate_srec_file
 from .merge import merge_srec_files
 from .edit import extract_range_srec, relocate_range_srec
 
@@ -9,4 +9,5 @@ __all__ = [
     "merge_srec_files",
     "extract_range_srec",
     "relocate_range_srec",
+    "validate_srec_file",
 ]

--- a/hexfix/checksum.py
+++ b/hexfix/checksum.py
@@ -17,6 +17,76 @@ def parse_srec_line(line):
     except ValueError:
         return None, None, None
 
+
+def validate_srec_file(filename, fix: bool = False):
+    """Validate checksums in an SREC file.
+
+    Each line is parsed and the checksum is recomputed from the byte count,
+    address bytes and data bytes. A list of line numbers with invalid
+    checksums is returned. When ``fix`` is ``True`` the checksums in these
+    lines are replaced with the recomputed values in the file on disk.
+
+    Parameters
+    ----------
+    filename: str
+        Path to the SREC file to validate.
+    fix: bool, optional
+        If ``True`` any checksum mismatches will be corrected in-place. The
+        list of offending line numbers is still returned.
+    """
+
+    invalid_lines = []
+    output_lines = []
+
+    with open(filename, "r") as infile:
+        lines = infile.readlines()
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.rstrip("\n")
+        if not stripped.startswith("S") or len(stripped) < 4:
+            output_lines.append(line)
+            continue
+
+        record_type = stripped[0:2]
+        try:
+            byte_count = int(stripped[2:4], 16)
+        except ValueError:
+            invalid_lines.append(lineno)
+            output_lines.append(line)
+            continue
+
+        # Address length in bytes for common record types
+        addr_len_map = {"S0": 2, "S1": 2, "S2": 3, "S3": 4, "S5": 2, "S7": 4, "S8": 3, "S9": 2}
+        addr_len = addr_len_map.get(record_type, 0)
+        addr_hex_len = addr_len * 2
+
+        try:
+            addr_bytes = bytes.fromhex(stripped[4:4 + addr_hex_len])
+            data_bytes = bytes.fromhex(stripped[4 + addr_hex_len:-2])
+            stored_checksum = int(stripped[-2:], 16)
+        except ValueError:
+            invalid_lines.append(lineno)
+            output_lines.append(line)
+            continue
+
+        calc_checksum = (~(byte_count + sum(addr_bytes) + sum(data_bytes)) & 0xFF)
+
+        if calc_checksum != stored_checksum:
+            invalid_lines.append(lineno)
+            if fix:
+                fixed_line = stripped[:-2] + f"{calc_checksum:02X}\n"
+                output_lines.append(fixed_line)
+            else:
+                output_lines.append(line)
+        else:
+            output_lines.append(line)
+
+    if fix and invalid_lines:
+        with open(filename, "w") as outfile:
+            outfile.writelines(output_lines)
+
+    return invalid_lines
+
 def crc32_for_address_range(srec_filename, start_address, end_address):
     """
     Calculates the CRC32 checksum from data records within a specified range in an SREC file.

--- a/tests/test_validate_checksum.py
+++ b/tests/test_validate_checksum.py
@@ -1,0 +1,37 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from hexfix.checksum import validate_srec_file
+from hexfix.edit import _encode_srec_line
+
+
+def test_validate_srec_file_valid(tmp_path):
+    """No errors are reported for a file with correct checksums."""
+    path = tmp_path / "in.srec"
+    lines = [
+        _encode_srec_line("S1", 0x0010, bytes(range(4))),
+        _encode_srec_line("S1", 0x0020, bytes(range(4, 8))),
+    ]
+    path.write_text("".join(lines))
+    assert validate_srec_file(str(path)) == []
+
+
+def test_validate_srec_file_fix(tmp_path):
+    """Lines with bad checksums are reported and can be fixed in-place."""
+    path = tmp_path / "bad.srec"
+    line1 = _encode_srec_line("S1", 0x0010, bytes(range(4)))
+    line2 = _encode_srec_line("S1", 0x0020, bytes(range(4, 8)))
+    # Corrupt the checksum of the second line
+    bad_line2 = line2[:-3] + "00\n"
+    path.write_text(line1 + bad_line2)
+
+    assert validate_srec_file(str(path)) == [2]
+    # Fix the file
+    assert validate_srec_file(str(path), fix=True) == [2]
+    # After fixing, file should validate cleanly
+    assert validate_srec_file(str(path)) == []
+    # And the contents restored
+    assert path.read_text().splitlines()[1] == line2.rstrip("\n")
+


### PR DESCRIPTION
## Summary
- add `validate_srec_file` to recompute and optionally fix SREC line checksums
- export `validate_srec_file` in package
- test checksum validation and fixing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c912ecec83339219d5d953c10a4d