### PR TITLE
Add SREC to binary conversion utility

### DIFF
--- a/hexfix/__init__.py
+++ b/hexfix/__init__.py
@@ -3,10 +3,12 @@
 from .checksum import crc32_for_address_range
 from .merge import merge_srec_files
 from .edit import extract_range_srec, relocate_range_srec
+from .convert import srec_to_binary
 
 __all__ = [
     "crc32_for_address_range",
     "merge_srec_files",
     "extract_range_srec",
     "relocate_range_srec",
+    "srec_to_binary",
 ]

--- a/hexfix/convert.py
+++ b/hexfix/convert.py
@@ -1,0 +1,76 @@
+"""Utilities for converting SREC data to binary."""
+from __future__ import annotations
+
+from typing import Iterable, Union
+
+
+def srec_to_binary(
+    srec: Union[str, Iterable[str]],
+    start_address: int = 0,
+    output_length: int | None = None,
+) -> bytes:
+    """Convert SREC data into a binary blob.
+
+    Parameters
+    ----------
+    srec: Union[str, Iterable[str]]
+        Either a path to an SREC file or an iterable of SREC lines.
+    start_address: int
+        First address that should appear in the output. Bytes below this
+        address are ignored and padding inserted if necessary.
+    output_length: int | None
+        Desired length of the output. If ``None`` the output will extend up to
+        the highest address encountered in the SREC data.
+
+    Returns
+    -------
+    bytes
+        Binary representation of the requested address range.
+    """
+    if isinstance(srec, str):
+        # Treat as filename
+        with open(srec, "r") as infile:
+            lines = infile.readlines()
+    else:
+        lines = list(srec)
+
+    records = []
+    max_address = start_address
+    for line in lines:
+        line = line.strip()
+        if not line.startswith("S"):
+            continue
+        record_type = line[:2]
+        addr_len = {"S1": 4, "S2": 6, "S3": 8}.get(record_type)
+        if addr_len is None:
+            continue
+        try:
+            address = int(line[4:4 + addr_len], 16)
+            data = bytes.fromhex(line[4 + addr_len : -2])
+        except ValueError:
+            continue
+        records.append((address, data))
+        rec_end = address + len(data)
+        if rec_end > max_address:
+            max_address = rec_end
+
+    if output_length is None:
+        length = max(0, max_address - start_address)
+    else:
+        length = output_length
+
+    output = bytearray([0xFF] * length)
+    for address, data in records:
+        if address + len(data) <= start_address:
+            continue
+        offset = address - start_address
+        if offset < 0:
+            data = data[-offset:]
+            offset = 0
+        end = offset + len(data)
+        if end > length:
+            data = data[: length - offset]
+            end = length
+        output[offset:end] = data
+
+    return bytes(output)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import hexfix
+
+
+def test_basic_conversion():
+    srec = """\
+S107000001020304EE
+S10500040506EB
+S9030000FC
+""".splitlines()
+    result = hexfix.srec_to_binary(srec)
+    assert result == bytes([1, 2, 3, 4, 5, 6])
+
+
+def test_gapped_conversion_with_padding():
+    srec = """\
+S1040100AA50
+S1040104BB3B
+S9030000FC
+""".splitlines()
+    result = hexfix.srec_to_binary(srec, start_address=0x0100, output_length=5)
+    assert result == bytes([0xAA, 0xFF, 0xFF, 0xFF, 0xBB])


### PR DESCRIPTION
## Summary
- add `srec_to_binary` to convert SREC records into binary with optional padding
- expose conversion helper through package init
- test basic and gapped SREC conversions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c914e8108333936bc841f2f76dc8